### PR TITLE
Implement detailed job page with dummy data

### DIFF
--- a/src/components/JobCard.jsx
+++ b/src/components/JobCard.jsx
@@ -2,10 +2,16 @@ import { Link } from 'react-router-dom';
 
 function JobCard({ job }) {
   return (
-    <div className="border p-4 rounded shadow">
-      <h3 className="text-lg font-bold">{job.titre}</h3>
-      <p>{job.lieu}</p>
-      <Link className="text-blue-600" to={`/jobs/${job.id}`}>Voir l'annonce</Link>
+    <div className="border p-4 rounded shadow transition-transform duration-300 hover:-translate-y-1 hover:shadow-lg">
+      <h3 className="text-lg font-bold mb-1">{job.titre}</h3>
+      <p className="mb-2">{job.ville}, {job.etat}</p>
+      <Link
+        className="text-blue-600"
+        to={`/jobs/${job.id}`}
+        state={{ job }}
+      >
+        Voir l'annonce
+      </Link>
     </div>
   );
 }

--- a/src/pages/JobDetail.jsx
+++ b/src/pages/JobDetail.jsx
@@ -1,11 +1,51 @@
-import { useParams } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 function JobDetail() {
-  const { id } = useParams();
+  const navigate = useNavigate();
+  const { state } = useLocation();
+  const job = state?.job;
+
+  if (!job) {
+    return (
+      <div className="text-center">
+        <p className="mb-4">Aucune donnée pour cette offre.</p>
+        <button
+          className="text-blue-600 underline"
+          onClick={() => navigate('/jobs')}
+        >
+          Retour aux offres
+        </button>
+      </div>
+    );
+  }
+
   return (
-    <div>
-      <h1 className="text-2xl">Détail de l'offre {id}</h1>
-      <p>Contenu à venir...</p>
+    <div className="border p-4 rounded shadow transition-opacity duration-300">
+      <h1 className="text-2xl font-bold mb-2">{job.titre}</h1>
+      <p className="mb-1 font-semibold">
+        {job.ville}, {job.etat}
+      </p>
+      <p className="mb-1 text-sm text-gray-600">Publié le {job.datePublication}</p>
+      <p className="mb-1">Type : {job.type}</p>
+      <p className="mb-4">Logement fourni : {job.logement ? 'Oui' : 'Non'}</p>
+      <p className="mb-4 whitespace-pre-line">{job.description}</p>
+      {/* Zone réservée pour la carte */}
+      <div className="bg-gray-100 h-40 rounded flex items-center justify-center mb-4">
+        <span className="text-gray-500">Carte à venir</span>
+      </div>
+      <div className="flex flex-col sm:flex-row sm:space-x-4">
+        <button
+          className="bg-blue-600 text-white px-4 py-2 rounded mb-2 sm:mb-0"
+        >
+          Postuler maintenant
+        </button>
+        <button
+          className="text-blue-600 underline"
+          onClick={() => navigate(-1)}
+        >
+          Retour aux offres
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/pages/Jobs.jsx
+++ b/src/pages/Jobs.jsx
@@ -2,8 +2,31 @@ import JobCard from '../components/JobCard';
 import FilterPanel from '../components/FilterPanel';
 
 function Jobs() {
-  // Placeholder job list
-  const jobs = [];
+  // Liste d'offres factices en attendant l'API
+  const jobs = [
+    {
+      id: 1,
+      titre: 'Serveur(se) en café',
+      ville: 'Sydney',
+      etat: 'NSW',
+      datePublication: '2024-02-20',
+      type: 'Restauration',
+      logement: false,
+      description:
+        "Nous recherchons un(e) serveur(se) dynamique pour rejoindre notre équipe dans un café animé du centre-ville de Sydney.",
+    },
+    {
+      id: 2,
+      titre: 'Ouvrier agricole',
+      ville: 'Bundaberg',
+      etat: 'QLD',
+      datePublication: '2024-02-18',
+      type: 'Ferme',
+      logement: true,
+      description:
+        "Travail saisonnier dans une ferme de fruits avec hébergement possible. Idéal pour compléter ses jours de ferme WHV.",
+    },
+  ];
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- add dummy job listings to display on `/jobs`
- enhance `JobCard` with animation and location display
- build `/jobs/:id` page showing full job details with navigation

## Testing
- `npm run build` *(fails: vite not found)*