### PR TITLE
Add ressource detail page

### DIFF
--- a/src/components/RessourceCard.jsx
+++ b/src/components/RessourceCard.jsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom';
 
 function RessourceCard({ ressource }) {
   const { slug, titre, type, categorie, tags = [], description } = ressource;
-  const buttonLabel = type === 'Vid\u00e9o' ? 'Regarder' : 'Lire';
+  const buttonLabel = type === 'Vidéo' ? 'Regarder' : 'Lire';
 
   return (
     <div className="border p-4 rounded shadow flex flex-col h-full">

--- a/src/data/ressources.js
+++ b/src/data/ressources.js
@@ -1,0 +1,52 @@
+export const ressources = [
+  {
+    slug: 'cv-australien',
+    titre: 'Comment faire un CV australien',
+    type: 'Article',
+    categorie: 'CV',
+    tags: ['CV'],
+    description: 'Les étapes essentielles pour créer un CV adapté au marché australien.',
+    datePublication: '2025-05-10',
+    contenu: 'Rédigez un résumé clair, mettez en avant vos expériences pertinentes et négligez pas les compétences spécifiques demandées en Australie.'
+  },
+  {
+    slug: 'modele-cv',
+    titre: 'Modèle de CV à télécharger',
+    type: 'Article',
+    categorie: 'CV',
+    tags: ['Modèle'],
+    description: 'Un exemple gratuit pour démarrer rapidement.',
+    datePublication: '2025-05-12',
+    contenu: "Téléchargez ce modèle de CV simple et efficace pour commencer votre recherche d'emploi en Australie."
+  },
+  {
+    slug: 'vie-en-australie',
+    titre: 'Vie en Australie : conseils pratiques',
+    type: 'Article',
+    categorie: 'Vie en Australie',
+    tags: ['Astuces'],
+    description: "Petits trucs pour s'adapter facilement une fois sur place.",
+    datePublication: '2025-05-08',
+    contenu: 'Découvrez comment trouver un logement, ouvrir un compte bancaire et vous déplacer sans stress lors de vos premières semaines.'
+  },
+  {
+    slug: 'video-entretien',
+    titre: 'Préparer son entretien en anglais',
+    type: 'Vidéo',
+    categorie: 'Entretien',
+    tags: ['Vidéo'],
+    description: 'Regardez comment répondre aux questions fréquentes.',
+    datePublication: '2025-05-15',
+    videoUrl: 'https://www.youtube.com/embed/dQw4w9WgXcQ'
+  },
+  {
+    slug: 'trouver-job',
+    titre: 'Trouver un job rapidement',
+    type: 'Vidéo',
+    categorie: 'Vie en Australie',
+    tags: ['Conseils'],
+    description: 'Nos conseils en vidéo pour décrocher vos premiers jobs.',
+    datePublication: '2025-05-18',
+    videoUrl: 'https://www.youtube.com/embed/oHg5SJYRHA0'
+  }
+];

--- a/src/pages/RessourceDetail.jsx
+++ b/src/pages/RessourceDetail.jsx
@@ -1,11 +1,64 @@
-import { useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
+import RessourceCard from '../components/RessourceCard';
+import { ressources } from '../data/ressources';
 
 function RessourceDetail() {
   const { slug } = useParams();
+  const ressource = ressources.find((r) => r.slug === slug);
+
+  if (!ressource) {
+    return (
+      <div className="space-y-4">
+        <Link to="/ressources" className="text-blue-600">← Retour aux ressources</Link>
+        <p>Ressource introuvable.</p>
+      </div>
+    );
+  }
+
+  const related = ressources
+    .filter((r) => r.slug !== slug)
+    .slice(0, 3);
+
   return (
-    <div>
-      <h1 className="text-2xl">Ressource {slug}</h1>
-      <p>Contenu à venir...</p>
+    <div className="space-y-6">
+      <Link to="/ressources" className="text-blue-600">← Retour aux ressources</Link>
+      <h1 className="text-2xl font-bold">{ressource.titre}</h1>
+      <div className="text-sm text-gray-600 flex flex-wrap gap-2">
+        <span className="bg-gray-200 px-2 py-1 rounded">{ressource.type}</span>
+        <span>{ressource.categorie}</span>
+        {ressource.tags &&
+          ressource.tags.map((tag) => (
+            <span
+              key={tag}
+              className="bg-blue-100 text-blue-800 px-2 py-0.5 rounded text-xs"
+            >
+              {tag}
+            </span>
+          ))}
+      </div>
+      <p className="text-sm text-gray-500">Publi\u00e9 le {ressource.datePublication}</p>
+      {ressource.contenu && <p className="leading-relaxed">{ressource.contenu}</p>}
+      {ressource.videoUrl && (
+        <div className="aspect-video">
+          <iframe
+            src={ressource.videoUrl}
+            title={ressource.titre}
+            className="w-full h-full"
+            allowFullScreen
+          />
+        </div>
+      )}
+
+      {related.length > 0 && (
+        <div className="mt-8">
+          <h2 className="text-xl font-semibold mb-4">Ressources associ\u00e9es</h2>
+          <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+            {related.map((r) => (
+              <RessourceCard key={r.slug} ressource={r} />
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/pages/Ressources.jsx
+++ b/src/pages/Ressources.jsx
@@ -1,51 +1,11 @@
 import { useState } from 'react';
 import RessourceCard from '../components/RessourceCard';
+import { ressources as allRessources } from '../data/ressources';
 
 function Ressources() {
   const [filters, setFilters] = useState({ type: '', categorie: '' });
 
-  const ressources = [
-    {
-      slug: 'cv-australien',
-      titre: 'Comment faire un CV australien',
-      type: 'Article',
-      categorie: 'CV',
-      tags: ['CV'],
-      description: 'Les étapes essentielles pour créer un CV adapté au marché australien.',
-    },
-    {
-      slug: 'modele-cv',
-      titre: 'Modèle de CV à télécharger',
-      type: 'Article',
-      categorie: 'CV',
-      tags: ['Modèle'],
-      description: 'Un exemple gratuit pour démarrer rapidement.',
-    },
-    {
-      slug: 'vie-en-australie',
-      titre: 'Vie en Australie : conseils pratiques',
-      type: 'Article',
-      categorie: 'Vie en Australie',
-      tags: ['Astuces'],
-      description: 'Petits trucs pour s\'adapter facilement une fois sur place.',
-    },
-    {
-      slug: 'video-entretien',
-      titre: 'Préparer son entretien en anglais',
-      type: 'Vidéo',
-      categorie: 'Entretien',
-      tags: ['Vidéo'],
-      description: 'Regardez comment répondre aux questions fréquentes.',
-    },
-    {
-      slug: 'trouver-job',
-      titre: 'Trouver un job rapidement',
-      type: 'Vidéo',
-      categorie: 'Vie en Australie',
-      tags: ['Conseils'],
-      description: 'Nos conseils en vidéo pour décrocher vos premiers jobs.',
-    },
-  ];
+  const ressources = allRessources;
 
   function updateField(field, value) {
     setFilters({ ...filters, [field]: value });


### PR DESCRIPTION
## Summary
- create shared dummy data for learning resources
- display list of resources from shared data
- implement `/ressources/:slug` detail page with back link and related resources
- fix `RessourceCard` video label string

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*